### PR TITLE
feat: #57 Security permitAll 추가 설정

### DIFF
--- a/src/main/java/com/sparta/be/config/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/be/config/WebSecurityConfig.java
@@ -52,6 +52,10 @@ public class WebSecurityConfig {
 
         http.authorizeHttpRequests().requestMatchers("/api/users/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/reviews/**").permitAll()
+                .requestMatchers(HttpMethod.PUT, "/api/reviews/**").permitAll()
+                .requestMatchers(HttpMethod.DELETE, "/api/reviews/**").permitAll()
+                .requestMatchers(HttpMethod.PUT, "/api/comments/**").permitAll()
+                .requestMatchers(HttpMethod.DELETE, "/api/comments/**").permitAll()
                 .anyRequest().authenticated()
                 .and().exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint())
                 .and().addFilterBefore(new JwtAuthFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
리뷰, 댓글을 수정, 삭제할 때 요청 자체가 작성자인 경우에만 들어오게 되어있으므로
permitAll 설정을 추가했다.

close #57 